### PR TITLE
Support new `mpdev tf overwrite` input that doesn't require existing default values

### DIFF
--- a/mpdev/internal/tf/overwrite_test.go
+++ b/mpdev/internal/tf/overwrite_test.go
@@ -127,55 +127,54 @@ func TestOverwriteTf(t *testing.T) {
 			},
 		},
 	},
-	{
-		name: "With NewValues, ignores Variables and Replacements",
-		tfFiles: map[string]string{
-			"main.tf":        mainTf,
-			"anyfilename.tf": otherTf,
-		},
-		expectedTfFiles: map[string]string{
-			"main.tf":        mainTfReplaced,
-			"anyfilename.tf": otherTfReplaced,
-		},
-		overwriteConfig: overwriteConfig{
-			NewValues: map[string]string{
-				"value_to_replace":       "new-value",
-				"other_value_to_replace": "newer-value",
-				"another_variable":       "newest-value",
+		{
+			name: "With NewValues, ignores Variables and Replacements",
+			tfFiles: map[string]string{
+				"main.tf":        mainTf,
+				"anyfilename.tf": otherTf,
 			},
-			Variables: []string{"value_to_replace", "other_value_to_replace", "another_variable"},
-			Replacements: map[string]string{
-				"original-value": "new-value-unused",
-				"old-value":      "newer-value-unused",
-				"oldest-value":   "newest-value-unused",
+			expectedTfFiles: map[string]string{
+				"main.tf":        mainTfReplaced,
+				"anyfilename.tf": otherTfReplaced,
 			},
-		},
-	}, {
-		name: "With NewValues, adds default value when variable has no default value set",
-		tfFiles: map[string]string{
-			"main.tf": tfNoDefault,
-		},
-		expectedTfFiles: map[string]string{
-			"main.tf": tfDefaultAdded,
-		},
-		overwriteConfig: overwriteConfig{
-			NewValues: map[string]string{
-				"value_to_replace": "new-value",
+			overwriteConfig: overwriteConfig{
+				NewValues: map[string]string{
+					"value_to_replace":       "new-value",
+					"other_value_to_replace": "newer-value",
+					"another_variable":       "newest-value",
+				},
+				Variables: []string{"value_to_replace", "other_value_to_replace", "another_variable"},
+				Replacements: map[string]string{
+					"original-value": "new-value-unused",
+					"old-value":      "newer-value-unused",
+					"oldest-value":   "newest-value-unused",
+				},
 			},
-		},
-
-	}, {
-		name: "With NewValues, fail when variable default value is not a string",
-		tfFiles: map[string]string{
-			"main.tf": tfNoDefaultWrongType,
-		},
-		overwriteConfig: overwriteConfig{
-			NewValues: map[string]string{
-				"value_to_replace": "new-value",
+		}, {
+			name: "With NewValues, adds default value when variable has no default value set",
+			tfFiles: map[string]string{
+				"main.tf": tfNoDefault,
 			},
+			expectedTfFiles: map[string]string{
+				"main.tf": tfDefaultAdded,
+			},
+			overwriteConfig: overwriteConfig{
+				NewValues: map[string]string{
+					"value_to_replace": "new-value",
+				},
+			},
+		}, {
+			name: "With NewValues, fail when variable default value is not a string",
+			tfFiles: map[string]string{
+				"main.tf": tfNoDefaultWrongType,
+			},
+			overwriteConfig: overwriteConfig{
+				NewValues: map[string]string{
+					"value_to_replace": "new-value",
+				},
+			},
+			errorContains: "image variable: value_to_replace must be type string",
 		},
-		errorContains: "image variable: value_to_replace must be type string",
-	},
 	}
 
 	for _, tc := range testcases {
@@ -310,7 +309,7 @@ func TestOverwriteMetadata(t *testing.T) {
 		expectedMetadata: metadataReplaced,
 		overwriteConfig: overwriteConfig{
 			NewValues: map[string]string{
-				"source_image":   "new-image",
+				"source_image":  "new-image",
 				"another_image": "newer-image",
 			},
 		},
@@ -320,8 +319,8 @@ func TestOverwriteMetadata(t *testing.T) {
 		expectedMetadata: metadataReplaced,
 		overwriteConfig: overwriteConfig{
 			NewValues: map[string]string{
-				"source_image":   "new-image",
-				"another_image": 	"newer-image",
+				"source_image":  "new-image",
+				"another_image": "newer-image",
 			},
 			Variables: []string{"source_image", "another_image"},
 			Replacements: map[string]string{
@@ -338,7 +337,7 @@ func TestOverwriteMetadata(t *testing.T) {
 			},
 		},
 		errorContains: "missing variable entry for variable: missing_variable",
-	},  {
+	}, {
 		name:             "With NewValues, adds default value when variable has no default value set",
 		originalMetadata: metadataNoDefault,
 		expectedMetadata: metadataDefaultAdded,

--- a/mpdev/internal/tf/overwrite_test.go
+++ b/mpdev/internal/tf/overwrite_test.go
@@ -110,7 +110,7 @@ func TestOverwriteTf(t *testing.T) {
 		},
 		errorContains: "default value: original-value of variable: value_to_replace not found in replacements",
 	}, {
-		name: "Use NewValues for replacements",
+		name: "With NewValues, overwrite multiple variables and files",
 		tfFiles: map[string]string{
 			"main.tf":        mainTf,
 			"anyfilename.tf": otherTf,
@@ -121,35 +121,61 @@ func TestOverwriteTf(t *testing.T) {
 		},
 		overwriteConfig: overwriteConfig{
 			NewValues: map[string]string{
-				"value_to_replace": "new-value",
+				"value_to_replace":       "new-value",
 				"other_value_to_replace": "newer-value",
-				"another_variable": "newest-value",
+				"another_variable":       "newest-value",
+			},
+		},
+	},
+	{
+		name: "With NewValues, ignores Variables and Replacements",
+		tfFiles: map[string]string{
+			"main.tf":        mainTf,
+			"anyfilename.tf": otherTf,
+		},
+		expectedTfFiles: map[string]string{
+			"main.tf":        mainTfReplaced,
+			"anyfilename.tf": otherTfReplaced,
+		},
+		overwriteConfig: overwriteConfig{
+			NewValues: map[string]string{
+				"value_to_replace":       "new-value",
+				"other_value_to_replace": "newer-value",
+				"another_variable":       "newest-value",
+			},
+			Variables: []string{"value_to_replace", "other_value_to_replace", "another_variable"},
+			Replacements: map[string]string{
+				"original-value": "new-value-unused",
+				"old-value":      "newer-value-unused",
+				"oldest-value":   "newest-value-unused",
 			},
 		},
 	}, {
-			name: "Ignores Variables and Replacements when NewValues is provided",
-			tfFiles: map[string]string{
-				"main.tf":        mainTf,
-				"anyfilename.tf": otherTf,
-			},
-			expectedTfFiles: map[string]string{
-				"main.tf":        mainTfReplaced,
-				"anyfilename.tf": otherTfReplaced,
-			},
-			overwriteConfig: overwriteConfig{
-				NewValues: map[string]string{
-					"value_to_replace": "new-value",
-					"other_value_to_replace": "newer-value",
-					"another_variable": "newest-value",
-				},
-				Variables: []string{"value_to_replace", "other_value_to_replace", "another_variable"},
-				Replacements: map[string]string{
-					"original-value": "new-value-unused",
-					"old-value":      "newer-value-unused",
-					"oldest-value":   "newest-value-unused",
-				},
+		name: "With NewValues, adds default value when variable has no default value set",
+		tfFiles: map[string]string{
+			"main.tf": tfNoDefault,
+		},
+		expectedTfFiles: map[string]string{
+			"main.tf": tfDefaultAdded,
+		},
+		overwriteConfig: overwriteConfig{
+			NewValues: map[string]string{
+				"value_to_replace": "new-value",
 			},
 		},
+
+	}, {
+		name: "With NewValues, fail when variable default value is not a string",
+		tfFiles: map[string]string{
+			"main.tf": tfNoDefaultWrongType,
+		},
+		overwriteConfig: overwriteConfig{
+			NewValues: map[string]string{
+				"value_to_replace": "new-value",
+			},
+		},
+		errorContains: "image variable: value_to_replace must be type string",
+	},
 	}
 
 	for _, tc := range testcases {
@@ -194,7 +220,10 @@ func TestGetOverwriteConfig(t *testing.T) {
 		configBytes: []byte(`
 {
 	"variables": ["source_image"],
-	"replacements": {"old_image": "new_image" }
+	"replacements": {"old_image": "new_image" },
+	"newValues": {
+		"source_image": "new_image"
+	}
 }
 `),
 		expectedConfig: overwriteConfig{
@@ -202,8 +231,12 @@ func TestGetOverwriteConfig(t *testing.T) {
 			Replacements: map[string]string{
 				"old_image": "new_image",
 			},
+			NewValues: map[string]string{
+				"source_image": "new_image",
+			},
 		},
-	}}
+	},
+	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -271,7 +304,51 @@ func TestOverwriteMetadata(t *testing.T) {
 			},
 		},
 		errorContains: "default value: old-image of variable: source_image in metadata.yaml not found in replacements",
-	}}
+	}, {
+		name:             "With NewValues, overwrite multiple variables",
+		originalMetadata: metadata,
+		expectedMetadata: metadataReplaced,
+		overwriteConfig: overwriteConfig{
+			NewValues: map[string]string{
+				"source_image":   "new-image",
+				"another_image": "newer-image",
+			},
+		},
+	}, {
+		name:             "With NewValues, ignores Variables and Replacements",
+		originalMetadata: metadata,
+		expectedMetadata: metadataReplaced,
+		overwriteConfig: overwriteConfig{
+			NewValues: map[string]string{
+				"source_image":   "new-image",
+				"another_image": 	"newer-image",
+			},
+			Variables: []string{"source_image", "another_image"},
+			Replacements: map[string]string{
+				"old-image":   "new-image-unused",
+				"older-image": "newer-image-unused",
+			},
+		},
+	}, {
+		name:             "With NewValues, fail when variable is not present in Metadata",
+		originalMetadata: metadata,
+		overwriteConfig: overwriteConfig{
+			NewValues: map[string]string{
+				"missing_variable": "new-value",
+			},
+		},
+		errorContains: "missing variable entry for variable: missing_variable",
+	},  {
+		name:             "With NewValues, adds default value when variable has no default value set",
+		originalMetadata: metadataNoDefault,
+		expectedMetadata: metadataDefaultAdded,
+		overwriteConfig: overwriteConfig{
+			NewValues: map[string]string{
+				"source_image": "new-value",
+			},
+		},
+	},
+	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -457,12 +534,12 @@ resource "google_compute_instance_template" "template" {
 }
 
 variable "value_to_replace" {
-  type = string
+  type    = string
   default = "original-value"
 }
 
 variable "other_value_to_replace" {
-  type = string
+  type    = string
   default = "old-value"
 }
 `
@@ -473,12 +550,12 @@ resource "google_compute_instance_template" "template" {
 }
 
 variable "value_to_replace" {
-  type = string
+  type    = string
   default = "new-value"
 }
 
 variable "other_value_to_replace" {
-  type = string
+  type    = string
   default = "newer-value"
 }
 `
@@ -492,7 +569,7 @@ variable "another_variable" {
 
 var otherTfReplaced string = `
 variable "another_variable" {
-  type = string
+  type    = string
   default = "newest-value"
 }
 `
@@ -503,6 +580,13 @@ variable "value_to_replace" {
 }
 `
 
+var tfDefaultAdded string = `
+variable "value_to_replace" {
+  type    = string
+  default = "new-value"
+}
+`
+
 var tfDefaultWrongType string = `
 variable "value_to_replace" {
   type = map(number)
@@ -510,6 +594,11 @@ variable "value_to_replace" {
     foo = 2
     bar = 4
   }
+}
+`
+var tfNoDefaultWrongType string = `
+variable "value_to_replace" {
+  type = map(number)
 }
 `
 
@@ -548,6 +637,16 @@ spec:
     - name: source_image
       description: The image name for the disk for the VM instance.
       varType: string
+`
+
+var metadataDefaultAdded string = `
+spec:
+  interfaces:
+    variables:
+    - name: source_image
+      description: The image name for the disk for the VM instance.
+      varType: string
+      defaultValue: new-value
 `
 
 var metadataDisplayWithEnumsSingle string = `

--- a/mpdev/internal/tf/overwrite_test.go
+++ b/mpdev/internal/tf/overwrite_test.go
@@ -109,7 +109,48 @@ func TestOverwriteTf(t *testing.T) {
 			},
 		},
 		errorContains: "default value: original-value of variable: value_to_replace not found in replacements",
-	}}
+	}, {
+		name: "Use NewValues for replacements",
+		tfFiles: map[string]string{
+			"main.tf":        mainTf,
+			"anyfilename.tf": otherTf,
+		},
+		expectedTfFiles: map[string]string{
+			"main.tf":        mainTfReplaced,
+			"anyfilename.tf": otherTfReplaced,
+		},
+		overwriteConfig: overwriteConfig{
+			NewValues: map[string]string{
+				"value_to_replace": "new-value",
+				"other_value_to_replace": "newer-value",
+				"another_variable": "newest-value",
+			},
+		},
+	}, {
+			name: "Ignores Variables and Replacements when NewValues is provided",
+			tfFiles: map[string]string{
+				"main.tf":        mainTf,
+				"anyfilename.tf": otherTf,
+			},
+			expectedTfFiles: map[string]string{
+				"main.tf":        mainTfReplaced,
+				"anyfilename.tf": otherTfReplaced,
+			},
+			overwriteConfig: overwriteConfig{
+				NewValues: map[string]string{
+					"value_to_replace": "new-value",
+					"other_value_to_replace": "newer-value",
+					"another_variable": "newest-value",
+				},
+				Variables: []string{"value_to_replace", "other_value_to_replace", "another_variable"},
+				Replacements: map[string]string{
+					"original-value": "new-value-unused",
+					"old-value":      "newer-value-unused",
+					"oldest-value":   "newest-value-unused",
+				},
+			},
+		},
+	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Add a `NewValues` field to the overwrite json input, which maps variable names to its new values (and doesn't require an existing DefaultValue). When `NewValues` is provided, `Variables` and `Replacements` are ignored.

Also format the entire tf file after overwriting.