### PR TITLE
Grant tag workflow permissions to create releases

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Upload Release Asset
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Currently the "Create release" step has been failing b/c the read/write permissions have been disabled on an org level. Manually setting permissions for the workflow should still work.