### PR TITLE
Add a consumer label upsert functionality to the mpdev tf overwrite command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ license-check:
 	$(GOBIN)/go-licenses check $(PKG)
 
 test:
-	bazel test //... --test_output=errors --stamp --workspace_status_command="./scripts/workspace-status.sh"
+	bazel test //... --test_output=errors --test_summary=detailed --cache_test_results=no --test_verbose_timeout_warnings --stamp --workspace_status_command="./scripts/workspace-status.sh"
 
 bazel-build-gen:
 	bazel run :gazelle -- update-repos -from_file=go.mod -build_file_proto_mode disable --to_macro=repos.bzl%go_repositories --prune

--- a/mpdev/internal/resources/BUILD.bazel
+++ b/mpdev/internal/resources/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "resource_test.go",
     ],
     embed = [":go_default_library"],
+    size = "small",
     deps = [
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",

--- a/mpdev/internal/tf/BUILD.bazel
+++ b/mpdev/internal/tf/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
     srcs = ["overwrite_test.go"],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
+    size = "small",
     deps = [
         "@com_github_stretchr_testify//assert:go_default_library",
         "@in_gopkg_yaml_v3//:go_default_library",

--- a/mpdev/internal/tf/overwrite.go
+++ b/mpdev/internal/tf/overwrite.go
@@ -192,6 +192,10 @@ func overwriteFile(filename string, varname string, value string) error {
 	return err
 }
 
+// Inserts a consumer label under the `provider "google"` block it does
+// not exist.
+// The `dir` parameter is the path to the TF main file.
+// The `label` parameter is the label value.
 func upsertConsumerLabel(dir string, label string) error {
 	// If the parameter is not provided, do nothing.
 	// This is for backward-compatibility purpose.

--- a/mpdev/internal/tf/overwrite.go
+++ b/mpdev/internal/tf/overwrite.go
@@ -192,7 +192,7 @@ func overwriteFile(filename string, varname string, value string) error {
 	return err
 }
 
-// Inserts a consumer label under the `provider "google"` block it does
+// Inserts a consumer label under the `provider "google"` block if it does
 // not exist.
 // The `dir` parameter is the path to the TF main file.
 // The `label` parameter is the label value.

--- a/mpdev/internal/tf/overwrite_test.go
+++ b/mpdev/internal/tf/overwrite_test.go
@@ -129,10 +129,10 @@ func TestOverwriteTf(t *testing.T) {
 	}, {
 		name: "With NewValues, overwrite multiple variables and files. Add consumer label",
 		tfFiles: map[string]string{
-			"main.tf":        mainTfNoLabel,
+			"main.tf": mainTfNoLabel,
 		},
 		expectedTfFiles: map[string]string{
-			"main.tf":        mainTfLabelUpserted,
+			"main.tf": mainTfLabelUpserted,
 		},
 		overwriteConfig: overwriteConfig{
 			ConsumerLabel: "new-consumer-label",
@@ -140,22 +140,22 @@ func TestOverwriteTf(t *testing.T) {
 				"value_to_replace": "new-value",
 			},
 		},
-		}, {
-			name: "With NewValues, overwrite multiple variables and files. Do not replace existing consumer label",
-			tfFiles: map[string]string{
-				"main.tf":        mainTfProvidedLabel,
-			},
-			expectedTfFiles: map[string]string{
-				"main.tf":        mainTfLabelUpserted,
-			},
-			overwriteConfig: overwriteConfig{
-				ConsumerLabel: "even-newer-consumer-label",
-				NewValues: map[string]string{
-					"value_to_replace": "new-value",
-				},
+	}, {
+		name: "With NewValues, overwrite multiple variables and files. Do not replace existing consumer label",
+		tfFiles: map[string]string{
+			"main.tf": mainTfProvidedLabel,
+		},
+		expectedTfFiles: map[string]string{
+			"main.tf": mainTfLabelUpserted,
+		},
+		overwriteConfig: overwriteConfig{
+			ConsumerLabel: "even-newer-consumer-label",
+			NewValues: map[string]string{
+				"value_to_replace": "new-value",
 			},
 		},
-			{
+	},
+		{
 			name: "With NewValues, ignores Variables and Replacements",
 			tfFiles: map[string]string{
 				"main.tf":        mainTf,

--- a/mpdev/internal/tf/overwrite_test.go
+++ b/mpdev/internal/tf/overwrite_test.go
@@ -126,8 +126,36 @@ func TestOverwriteTf(t *testing.T) {
 				"another_variable":       "newest-value",
 			},
 		},
-	},
-		{
+	}, {
+		name: "With NewValues, overwrite multiple variables and files. Add consumer label",
+		tfFiles: map[string]string{
+			"main.tf":        mainTfNoLabel,
+		},
+		expectedTfFiles: map[string]string{
+			"main.tf":        mainTfLabelUpserted,
+		},
+		overwriteConfig: overwriteConfig{
+			ConsumerLabel: "new-consumer-label",
+			NewValues: map[string]string{
+				"value_to_replace": "new-value",
+			},
+		},
+		}, {
+			name: "With NewValues, overwrite multiple variables and files. Do not replace existing consumer label",
+			tfFiles: map[string]string{
+				"main.tf":        mainTfProvidedLabel,
+			},
+			expectedTfFiles: map[string]string{
+				"main.tf":        mainTfLabelUpserted,
+			},
+			overwriteConfig: overwriteConfig{
+				ConsumerLabel: "even-newer-consumer-label",
+				NewValues: map[string]string{
+					"value_to_replace": "new-value",
+				},
+			},
+		},
+			{
 			name: "With NewValues, ignores Variables and Replacements",
 			tfFiles: map[string]string{
 				"main.tf":        mainTf,
@@ -556,6 +584,57 @@ variable "value_to_replace" {
 variable "other_value_to_replace" {
   type    = string
   default = "newer-value"
+}
+`
+
+var mainTfNoLabel string = `
+provider "google" {
+  project = var.project_id
+}
+
+resource "google_compute_instance_template" "template" {
+  name = "template"
+}
+
+variable "value_to_replace" {
+  type    = string
+  default = "original-value"
+}
+`
+
+var mainTfProvidedLabel string = `
+provider "google" {
+  project = var.project_id
+  default_labels {
+    goog-partner-solution = "new-consumer-label"
+  }
+}
+
+resource "google_compute_instance_template" "template" {
+  name = "template"
+}
+
+variable "value_to_replace" {
+  type    = string
+  default = "original-value"
+}
+`
+
+var mainTfLabelUpserted string = `
+provider "google" {
+  project = var.project_id
+  default_labels {
+    goog-partner-solution = "new-consumer-label"
+  }
+}
+
+resource "google_compute_instance_template" "template" {
+  name = "template"
+}
+
+variable "value_to_replace" {
+  type    = string
+  default = "new-value"
 }
 `
 


### PR DESCRIPTION
- Improved error output for test runs and fixed test warnings by adding the size attributes.
- Introduced a method to upsert a consumer label into the TF config