### PR TITLE
Require hashicorp/google >= 5.0.0 in examples.

### DIFF
--- a/docs/terraform-k8s-app/starter-terraform-module/gke.tf
+++ b/docs/terraform-k8s-app/starter-terraform-module/gke.tf
@@ -74,7 +74,7 @@ data "google_compute_subnetwork" "subnetwork" {
 module "gke" {
   count   = var.create_cluster ? 1 : 0
   source  = "terraform-google-modules/kubernetes-engine/google"
-  version = "~> 27.0"
+  version = ">= 29.0"
 
   project_id             = var.project_id
   create_service_account = var.create_cluster_service_account

--- a/docs/terraform-k8s-app/starter-terraform-module/versions.tf
+++ b/docs/terraform-k8s-app/starter-terraform-module/versions.tf
@@ -16,6 +16,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = ">= 5.0.0"
     }
     google-beta = {
       source = "hashicorp/google-beta"

--- a/examples/terraform/wordpress/versions.tf
+++ b/examples/terraform/wordpress/versions.tf
@@ -14,28 +14,12 @@
  * limitations under the License.
  */
 
-/**
- * Copyright 2021 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.53, < 5.0"
+      version = ">= 5.0.0"
     }
 
     random = {

--- a/examples/terraform_k8s/flask_app/tf/gke.tf
+++ b/examples/terraform_k8s/flask_app/tf/gke.tf
@@ -74,7 +74,7 @@ data "google_compute_subnetwork" "subnetwork" {
 module "gke" {
   count   = var.create_cluster ? 1 : 0
   source  = "terraform-google-modules/kubernetes-engine/google"
-  version = "~> 27.0"
+  version = ">= 29.0"
 
   project_id             = var.project_id
   create_service_account = var.create_cluster_service_account

--- a/examples/terraform_k8s/flask_app/tf/versions.tf
+++ b/examples/terraform_k8s/flask_app/tf/versions.tf
@@ -16,6 +16,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = ">= 5.0.0"
     }
     google-beta = {
       source = "hashicorp/google-beta"


### PR DESCRIPTION
5.0.0 is the minimum version that supports default_labels.